### PR TITLE
Arreglos dentro de ServciosDePaseoImp

### DIFF
--- a/TP2_Grupo1/src/main/java/ar/edu/unju/fi/service/imp/ServicioDePaseosImp.java
+++ b/TP2_Grupo1/src/main/java/ar/edu/unju/fi/service/imp/ServicioDePaseosImp.java
@@ -89,4 +89,16 @@ public class ServicioDePaseosImp implements IServicioDePaseosService{
 	public void guardarServicio(ServicioDePaseo servicioAGuardar) {
 		serviciosLista.getServiciosDePaseo().add(servicioAGuardar);
 	}
+
+	@Override
+	public ServicioDePaseo getBy(Long id) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void borrarServicio(ServicioDePaseo servicio) {
+		// TODO Auto-generated method stub
+		
+	}
 }


### PR DESCRIPTION
A pesar de que esta implementación ya no se usa, se debe agregar métodos que solicita por contrato, pero no tienen funcionalidad y nunca se usan.